### PR TITLE
Remove extra $'' quoting, as it was breaking the function for screen

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -15,10 +15,10 @@
           termtitle_format='%n@%m: %~'
       case ${TERM} in
         screen)
-          builtin eval "termtitle_update_${zhook}() { print -Pn $'\Ek'${(qq)termtitle_format}$'\E\\' }"
+          builtin eval "termtitle_update_${zhook}() { print -Pn '\Ek'${(qq)termtitle_format}'\E\\' }"
           ;;
         *)
-          builtin eval "termtitle_update_${zhook}() { print -Pn $'\E]0;'${(qq)termtitle_format}$'\a' }"
+          builtin eval "termtitle_update_${zhook}() { print -Pn '\E]0;'${(qq)termtitle_format}'\a' }"
           ;;
       esac
     fi


### PR DESCRIPTION
`print` interprets those escapes anyway, so having this just seems to add complexity